### PR TITLE
Remove -lerl_interface

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -4,7 +4,7 @@ SAFEIO_CFLAGS := -Wno-unused-parameter
 
 CFLAGS := -W -Wall -g $(SAFEIO_CFLAGS) -I $(ERL_TOP)/usr/include/
 LDFLAGS := -rdynamic -L$(ERL_TOP)/usr/lib/
-LDLIBS := -lei -lerl_interface
+LDLIBS := -lei
 
 .PHONY: all
 all: safeio_port

--- a/src/safeio.app.src
+++ b/src/safeio.app.src
@@ -1,7 +1,7 @@
 {application, safeio,
  [
   {description, "Check for stale (NFS) files/directories without locking up all file IO."},
-  {vsn, "0.1.5"},
+  {vsn, "0.1.6"},
   {registered, [safeio_sup]},
   {applications, [kernel, stdlib, sasl]},
   {mod, {safeio_app, []}},

--- a/src/safeio.appup.src
+++ b/src/safeio.appup.src
@@ -1,10 +1,12 @@
-{"0.1.5",
+{"0.1.6",
  [
+  {"0.1.5", [{restart_application, safeio}]},
   {"0.1.4", [{restart_application, safeio}]},
   {"0.1.3", [{restart_application, safeio}]},
   {"0.1.2", [{restart_application, safeio}]}
  ],
  [
+  {"0.1.5", [{restart_application, safeio}]},
   {"0.1.4", [{restart_application, safeio}]},
   {"0.1.3", [{restart_application, safeio}]},
   {"0.1.2", [{restart_application, safeio}]}


### PR DESCRIPTION
Not needed any more and it clashes with erlang R23 as there is no liberl_interface.a any more.